### PR TITLE
Fix Error 500, because the Order payload does not contains the text

### DIFF
--- a/src/WebHook/Notification/MessageNotificationFactory.php
+++ b/src/WebHook/Notification/MessageNotificationFactory.php
@@ -88,7 +88,6 @@ class MessageNotificationFactory
                     $message['id'],
                     new Support\Business($metadata['phone_number_id'], $metadata['display_phone_number']),
                     $message['order']['catalog_id'],
-                    $message['order']['text'],
                     new Support\Products($message['order']['product_items']),
                     $message['timestamp']
                 );

--- a/src/WebHook/Notification/MessageNotificationFactory.php
+++ b/src/WebHook/Notification/MessageNotificationFactory.php
@@ -88,6 +88,7 @@ class MessageNotificationFactory
                     $message['id'],
                     new Support\Business($metadata['phone_number_id'], $metadata['display_phone_number']),
                     $message['order']['catalog_id'],
+                    $message['order']['text'] ?? '',
                     new Support\Products($message['order']['product_items']),
                     $message['timestamp']
                 );

--- a/src/WebHook/Notification/Order.php
+++ b/src/WebHook/Notification/Order.php
@@ -26,6 +26,7 @@ final class Order extends MessageNotification
     }
 
     public function catalogId(): string
+    {
         return $this->catalog_id;
     }
 

--- a/src/WebHook/Notification/Order.php
+++ b/src/WebHook/Notification/Order.php
@@ -7,24 +7,31 @@ use Netflie\WhatsAppCloudApi\WebHook\Notification\Support\Products;
 final class Order extends MessageNotification
 {
     private string $catalog_id;
+    private string $message;
     private Products $products;
 
     public function __construct(
         string $id,
         Support\Business $business,
         string $catalog_id,
+        string $message,
         Products $products,
         string $received_at_timestamp
     ) {
         parent::__construct($id, $business, $received_at_timestamp);
 
         $this->catalog_id = $catalog_id;
+        $this->message = $message;
         $this->products = $products;
     }
 
     public function catalogId(): string
-    {
         return $this->catalog_id;
+    }
+
+    public function message(): string
+    {
+        return $this->message;
     }
 
     public function products(): Products

--- a/src/WebHook/Notification/Order.php
+++ b/src/WebHook/Notification/Order.php
@@ -7,32 +7,24 @@ use Netflie\WhatsAppCloudApi\WebHook\Notification\Support\Products;
 final class Order extends MessageNotification
 {
     private string $catalog_id;
-    private string $message;
     private Products $products;
 
     public function __construct(
         string $id,
         Support\Business $business,
         string $catalog_id,
-        string $message,
         Products $products,
         string $received_at_timestamp
     ) {
         parent::__construct($id, $business, $received_at_timestamp);
 
         $this->catalog_id = $catalog_id;
-        $this->message = $message;
         $this->products = $products;
     }
 
     public function catalogId(): string
     {
         return $this->catalog_id;
-    }
-
-    public function message(): string
-    {
-        return $this->message;
     }
 
     public function products(): Products


### PR DESCRIPTION
You are trying to retrieve the text inside the order payload.

Here is what I receive:
```
array:5 [
  "from" => "243904902349"
  "id" => "wamid.HBgMMjQzOTA0MDk0MDUxFQIAEhgUM0FDQkVDQTM5RUZDQkFFQjA3NDkA"
  "timestamp" => "1675284371"
  "type" => "order"
  "order" => array:2 [
    "catalog_id" => "547570977294794"
    "product_items" => array:2 [
      0 => array:4 [
        "product_retailer_id" => "ITEM001-1"
        "quantity" => 1
        "item_price" => 13
        "currency" => "USD"
      ]
      1 => array:4 [
        "product_retailer_id" => "ITEM001-3"
        "quantity" => 2
        "item_price" => 50
        "currency" => "USD"
      ]
    ]
  ]
]
```