### PR TITLE
The Context ID should be optional in forwarded messages

### DIFF
--- a/src/WebHook/Notification/MessageNotificationFactory.php
+++ b/src/WebHook/Notification/MessageNotificationFactory.php
@@ -129,7 +129,7 @@ class MessageNotificationFactory
             }
 
             $notification->withContext(new Support\Context(
-                $message['context']['id'],
+                $message['context']['id'] ?? null,
                 $message['context']['forwarded'] ?? false,
                 $referred_product ?? null
             ));

--- a/src/WebHook/Notification/Support/Context.php
+++ b/src/WebHook/Notification/Support/Context.php
@@ -4,14 +4,14 @@ namespace Netflie\WhatsAppCloudApi\WebHook\Notification\Support;
 
 final class Context
 {
-    private string $replying_to_message_id;
+    private ?string $replying_to_message_id;
 
     private bool $forwarded;
 
     private ?ReferredProduct $referred_product;
 
     public function __construct(
-        string $replying_to_message_id,
+        string $replying_to_message_id = null,
         bool $forwarded = false,
         ReferredProduct $referred_product = null
     ) {
@@ -20,7 +20,7 @@ final class Context
         $this->referred_product = $referred_product;
     }
 
-    public function replyingToMessageId(): string
+    public function replyingToMessageId(): ?string
     {
         return $this->replying_to_message_id;
     }

--- a/tests/Unit/WebHook/NotificationFactoryTest.php
+++ b/tests/Unit/WebHook/NotificationFactoryTest.php
@@ -892,6 +892,53 @@ final class NotificationFactoryTest extends TestCase
         $this->assertEquals('ERROR_TITLE', $notification->errorTitle());
     }
 
+    public function test_build_from_payload_can_build_a_forwarded_notification()
+    {
+        $payload = json_decode('{
+          "object": "whatsapp_business_account",
+          "entry": [{
+              "id": "WHATSAPP_BUSINESS_ACCOUNT_ID",
+              "changes": [{
+                  "value": {
+                      "messaging_product": "whatsapp",
+                      "metadata": {
+                          "display_phone_number": "PHONE_NUMBER",
+                          "phone_number_id": "PHONE_NUMBER_ID"
+                      },
+                      "contacts": [{
+                          "profile": {
+                            "name": "NAME"
+                          },
+                          "wa_id": "WHATSAPP_ID"
+                        }],
+                      "messages": [{
+                          "context": {
+                            "forwarded": true
+                          },
+                          "from": "16315551234",
+                          "id": "wamid.ID",
+                          "timestamp": 1669233778,
+                          "type": "text",
+                          "text": {
+                            "body": "MESSAGE_BODY"
+                          }
+                        }]
+                  },
+                  "field": "messages"
+                }]
+            }]
+        }', true);
+
+        $notification = $this->notification_factory->buildFromPayload($payload);
+
+        $this->assertNull($notification->replyingToMessageId());
+        $this->assertEquals('PHONE_NUMBER_ID', $notification->businessPhoneNumberId());
+        $this->assertEquals('PHONE_NUMBER', $notification->businessPhoneNumber());
+        $this->assertTrue($notification->isForwarded());
+        $this->assertEquals('WHATSAPP_ID', $notification->customer()->id());
+        $this->assertEquals('NAME', $notification->customer()->name());
+    }
+
     public function test_build_from_payload_return_null_when_payload_is_empty()
     {
         $notification = $this->notification_factory->buildFromPayload([]);


### PR DESCRIPTION
As per [this discussion](https://github.com/netflie/whatsapp-cloud-api/issues/94), the`$message['context']['id']` field is not always present when a message is forwarded, so it should be optional.