### PR TITLE
Initialize MessageNotification properties

### DIFF
--- a/src/WebHook/Notification/MessageNotification.php
+++ b/src/WebHook/Notification/MessageNotification.php
@@ -6,11 +6,11 @@ use Netflie\WhatsAppCloudApi\WebHook\Notification;
 
 abstract class MessageNotification extends Notification
 {
-    protected ?Support\Context $context;
+    protected ?Support\Context $context = null;
 
-    protected ?Support\Customer $customer;
+    protected ?Support\Customer $customer = null;
 
-    protected ?Support\Referral $referral;
+    protected ?Support\Referral $referral = null;
 
     public function customer(): ?Support\Customer
     {


### PR DESCRIPTION
### Description
I have noticed the following error message when calling `if ($messageNotification->context() !== null) {...}` (for example) recently:
```
Uncaught PHP Exception Symfony\Component\Messenger\Exception\HandlerFailedException: "Handling "App\My\Class\Here" failed: Typed property Netflie\WhatsAppCloudApi\WebHook\Notification\MessageNotification::$context must not be accessed before initialization"
```

Perhaps there is a good reason why these properties are not initialized, so feel free to reject this pull request 😄 

Thanks for the awesome SDK! ❤️ 