### PR TITLE
Allow multiple entries and changes within one webhook call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## XXX
+
+### What's Changed
+
+- Added readAll() method to get all notifications of a webhook call. See PR #132
+
 ## 2.1.0 - 2023-08-12
 
 ### What's Changed

--- a/README.md
+++ b/README.md
@@ -294,7 +294,11 @@ fwrite(STDOUT, print_r($payload, true) . "\n");
 // Instantiate the Webhook super class.
 $webhook = new WebHook();
 
+// Read the first message
 fwrite(STDOUT, print_r($webhook->read(json_decode($payload, true)), true) . "\n");
+
+//Read all messages in case Meta decided to batch them
+fwrite(STDOUT, print_r($webhook->readAll(json_decode($payload, true)), true) . "\n");
 ```
 
 The `Webhook::read` function will return a `Notification` instance. Please, [explore](https://github.com/netflie/whatsapp-cloud-api/tree/main/src/WebHook/Notification "explore") the different notifications availables.

--- a/src/WebHook.php
+++ b/src/WebHook.php
@@ -31,4 +31,16 @@ class WebHook
         return (new NotificationFactory())
             ->buildFromPayload($payload);
     }
+
+    /**
+     * Get all notifications from incoming webhook messages.
+     *
+     * @param  array  $payload Payload received in your endpoint URL.
+     * @return Notification[]    A PHP representation of WhatsApp webhook notifications
+     */
+    public function readAll(array $payload): array
+    {
+        return (new NotificationFactory())
+            ->buildAllFromPayload($payload);
+    }
 }

--- a/src/WebHook/NotificationFactory.php
+++ b/src/WebHook/NotificationFactory.php
@@ -31,14 +31,12 @@ final class NotificationFactory
 
         $notifications = [];
 
-        foreach($payload['entry'] as $entry) {
-
-            if(!is_array($entry['changes'])) {
+        foreach ($payload['entry'] as $entry) {
+            if (!is_array($entry['changes'])) {
                 continue;
             }
 
-            foreach($entry['changes'] as $change) {
-
+            foreach ($entry['changes'] as $change) {
                 $message = $change['value']['messages'][0] ?? [];
                 $status = $change['value']['statuses'][0] ?? [];
                 $contact = $change['value']['contacts'][0] ?? [];

--- a/src/WebHook/NotificationFactory.php
+++ b/src/WebHook/NotificationFactory.php
@@ -15,24 +15,45 @@ final class NotificationFactory
 
     public function buildFromPayload(array $payload): ?Notification
     {
+        $notifications = $this->buildAllFromPayload($payload);
+
+        return $notifications[0] ?? null;
+    }
+
+    /**
+     * @return Notification[]
+     */
+    public function buildAllFromPayload(array $payload): array
+    {
         if (!is_array($payload['entry'] ?? null)) {
-            return null;
+            return [];
         }
 
-        $entry = $payload['entry'][0] ?? [];
-        $message = $entry['changes'][0]['value']['messages'][0] ?? [];
-        $status = $entry['changes'][0]['value']['statuses'][0] ?? [];
-        $contact = $entry['changes'][0]['value']['contacts'][0] ?? [];
-        $metadata = $entry['changes'][0]['value']['metadata'] ?? [];
+        $notifications = [];
 
-        if ($message) {
-            return $this->message_notification_factory->buildFromPayload($metadata, $message, $contact);
+        foreach($payload['entry'] as $entry) {
+
+            if(!is_array($entry['changes'])) {
+                continue;
+            }
+
+            foreach($entry['changes'] as $change) {
+
+                $message = $change['value']['messages'][0] ?? [];
+                $status = $change['value']['statuses'][0] ?? [];
+                $contact = $change['value']['contacts'][0] ?? [];
+                $metadata = $change['value']['metadata'] ?? [];
+
+                if ($message) {
+                    $notifications[] = $this->message_notification_factory->buildFromPayload($metadata, $message, $contact);
+                }
+
+                if ($status) {
+                    $notifications[] = $this->status_notification_factory->buildFromPayload($metadata, $status);
+                }
+            }
         }
 
-        if ($status) {
-            return $this->status_notification_factory->buildFromPayload($metadata, $status);
-        }
-
-        return null;
+        return $notifications;
     }
 }

--- a/tests/Unit/WebHook/NotificationFactoryTest.php
+++ b/tests/Unit/WebHook/NotificationFactoryTest.php
@@ -135,6 +135,75 @@ final class NotificationFactoryTest extends TestCase
         $this->assertEquals('MESSAGE_BODY', $notification->message());
     }
 
+    public function test_build_from_payload_can_build_multiple_text_notification()
+    {
+        $payload = json_decode('{
+          "object": "whatsapp_business_account",
+          "entry": [{
+              "id": "WHATSAPP_BUSINESS_ACCOUNT_ID",
+              "changes": [{
+                  "value": {
+                      "messaging_product": "whatsapp",
+                      "metadata": {
+                          "display_phone_number": "PHONE_NUMBER",
+                          "phone_number_id": "PHONE_NUMBER_ID"
+                      },
+                      "contacts": [{
+                          "profile": {
+                            "name": "NAME"
+                          },
+                          "wa_id": "PHONE_NUMBER"
+                        }],
+                      "messages": [{
+                          "from": "PHONE_NUMBER",
+                          "id": "wamid.ID",
+                          "timestamp": "1669233778",
+                          "text": {
+                            "body": "MESSAGE_BODY"
+                          },
+                          "type": "text"
+                        }]
+                  },
+                  "field": "messages"
+                },
+                {
+                  "value": {
+                      "messaging_product": "whatsapp",
+                      "metadata": {
+                          "display_phone_number": "PHONE_NUMBER",
+                          "phone_number_id": "PHONE_NUMBER_ID"
+                      },
+                      "contacts": [{
+                          "profile": {
+                            "name": "NAME"
+                          },
+                          "wa_id": "PHONE_NUMBER"
+                        }],
+                      "messages": [{
+                          "from": "PHONE_NUMBER",
+                          "id": "wamid.ID",
+                          "timestamp": "1669233779",
+                          "text": {
+                            "body": "MESSAGE_BODY2"
+                          },
+                          "type": "text"
+                        }]
+                  },
+                  "field": "messages"
+                }]
+          }]
+        }', true);
+
+        $notifications = $this->notification_factory->buildAllFromPayload($payload);
+
+        $this->assertCount(2, $notifications);
+
+        $this->assertInstanceOf(Notification\Text::class, $notifications[0]);
+        $this->assertInstanceOf(Notification\Text::class, $notifications[1]);
+        $this->assertEquals('MESSAGE_BODY', $notifications[0]->message());
+        $this->assertEquals('MESSAGE_BODY2', $notifications[1]->message());
+    }
+
     public function test_build_from_payload_can_build_a_reaction_notification()
     {
         $payload = json_decode('{


### PR DESCRIPTION
As written in this discussion: https://github.com/netflie/whatsapp-cloud-api/discussions/129 whe webhook call might contain several changes if Facebook decides to batch them. Currently all but the first one are discarded.

This PR introduces a new readAll() method which returns all provided notifications.