### PR TITLE
fix-send-document-caption-optional: document caption is not required,…

### DIFF
--- a/src/Message/DocumentMessage.php
+++ b/src/Message/DocumentMessage.php
@@ -31,7 +31,7 @@ final class DocumentMessage extends Message
     /**
     * {@inheritdoc}
     */
-    public function __construct(string $to, MediaID $id, string $name, ?string $caption = '', ?string $reply_to)
+    public function __construct(string $to, MediaID $id, string $name, ?string $caption, ?string $reply_to)
     {
         $this->id = $id;
         $this->name = $name;

--- a/src/Message/DocumentMessage.php
+++ b/src/Message/DocumentMessage.php
@@ -31,7 +31,7 @@ final class DocumentMessage extends Message
     /**
     * {@inheritdoc}
     */
-    public function __construct(string $to, MediaID $id, string $name, ?string $caption, ?string $reply_to)
+    public function __construct(string $to, MediaID $id, string $name, ?string $caption = '', ?string $reply_to)
     {
         $this->id = $id;
         $this->name = $name;

--- a/src/WhatsAppCloudApi.php
+++ b/src/WhatsAppCloudApi.php
@@ -94,7 +94,7 @@ class WhatsAppCloudApi
      *
      * @throws Response\ResponseException
      */
-    public function sendDocument(string $to, MediaID $document_id, string $name, ?string $caption): Response
+    public function sendDocument(string $to, MediaID $document_id, string $name, ?string $caption = ''): Response
     {
         $message = new Message\DocumentMessage($to, $document_id, $name, $caption, $this->reply_to);
         $request = new Request\MessageRequest\RequestDocumentMessage(


### PR DESCRIPTION
The caption parameter is optional (https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages)
Updated the sendDocument caption default value is empty, the caption is not a required parameter now.