### PR TITLE
Implement CTA URL message

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,21 @@ $whatsapp_cloud_api->sendList(
 );
 ```
 
+### Send a CTA URL message
+
+```php
+<?php
+
+$whatsapp_cloud_api->sendCtaUrl(
+    '<destination-phone-number>',
+    'See Dates',
+    'https://www.example.com',
+    'Booking',
+    'Tap the button below to see available dates.',
+    'Dates subject to change.',
+);
+```
+
 ### Send a button reply message
 
 ```php

--- a/src/Message/CtaUrlMessage.php
+++ b/src/Message/CtaUrlMessage.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Netflie\WhatsAppCloudApi\Message;
+
+final class CtaUrlMessage extends Message
+{
+    /**
+    * {@inheritdoc}
+    */
+    protected string $type = 'cta_url';
+
+    private string $displayText;
+
+    private string $url;
+
+    private ?string $header = null;
+
+    private ?string $body = null;
+
+    private ?string $footer = null;
+
+    /**
+    * {@inheritdoc}
+    */
+    public function __construct(
+        string $to,
+        string $displayText,
+        string $url,
+        ?string $header,
+        ?string $body,
+        ?string $footer,
+        ?string $reply_to)
+    {
+        $this->displayText = $displayText;
+        $this->url = $url;
+        $this->header = $header;
+        $this->body = $body;
+        $this->footer = $footer;
+
+        parent::__construct($to, $reply_to);
+    }
+
+    public function getDisplayText(): string
+    {
+        return $this->displayText;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function header(): ?string
+    {
+        return $this->header;
+    }
+
+    public function body(): ?string
+    {
+        return $this->body;
+    }
+
+    public function footer(): ?string
+    {
+        return $this->footer;
+    }
+
+    public function action(): array
+    {
+        return [
+            'name' => $this->type,
+            'parameters' => [
+                'display_text' => $this->displayText,
+                'url' => $this->url,
+            ],
+        ];
+    }
+}

--- a/src/Message/CtaUrlMessage.php
+++ b/src/Message/CtaUrlMessage.php
@@ -29,8 +29,8 @@ final class CtaUrlMessage extends Message
         ?string $header,
         ?string $body,
         ?string $footer,
-        ?string $reply_to)
-    {
+        ?string $reply_to
+    ) {
         $this->displayText = $displayText;
         $this->url = $url;
         $this->header = $header;

--- a/src/Request/MessageRequest/RequestCtaUrlMessage.php
+++ b/src/Request/MessageRequest/RequestCtaUrlMessage.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Netflie\WhatsAppCloudApi\Request\MessageRequest;
+
+use Netflie\WhatsAppCloudApi\Request\MessageRequest;
+
+final class RequestCtaUrlMessage extends MessageRequest
+{
+    /**
+    * {@inheritdoc}
+    */
+    public function body(): array
+    {
+        $body = [
+            'messaging_product' => $this->message->messagingProduct(),
+            'recipient_type' => $this->message->recipientType(),
+            'to' => $this->message->to(),
+            'type' => 'interactive',
+            'interactive' => [
+                'type' => $this->message->type(),
+                'action' => $this->message->action(),
+            ],
+        ];
+
+        if ($this->message->header()) {
+            $body['interactive']['header'] = [
+                'type' => 'text',
+                'text' => $this->message->header(),
+            ];
+        }
+
+        if ($this->message->body()) {
+            $body['interactive']['body'] = ['text' => $this->message->body()];
+        }
+
+        if ($this->message->footer()) {
+            $body['interactive']['footer'] = ['text' => $this->message->footer()];
+        }
+
+        if ($this->message->replyTo()) {
+            $body['context']['message_id'] = $this->message->replyTo();
+        }
+
+        return $body;
+    }
+}

--- a/src/WhatsAppCloudApi.php
+++ b/src/WhatsAppCloudApi.php
@@ -276,6 +276,19 @@ class WhatsAppCloudApi
         return $this->client->sendMessage($request);
     }
 
+    /**
+     * Sends a list
+     *
+     * @param  string   $to     WhatsApp ID or phone number for the person you want to send a message to.
+     * @param  string   $header The header.
+     * @param  string   $body   The body.
+     * @param  string   $footer The footer.
+     * @param  Action   $action The action object.
+     *
+     * @return Response
+     *
+     * @throws Response\ResponseException
+     */
     public function sendList(string $to, string $header, string $body, string $footer, Action $action): Response
     {
         $message = new Message\OptionsListMessage($to, $header, $body, $footer, $action, $this->reply_to);

--- a/src/WhatsAppCloudApi.php
+++ b/src/WhatsAppCloudApi.php
@@ -289,6 +289,33 @@ class WhatsAppCloudApi
         return $this->client->sendMessage($request);
     }
 
+    /**
+     * Sends a CTA URL
+     *
+     * @param  string   $to             WhatsApp ID or phone number for the person you want to send a message to.
+     * @param  string   $displayText    The display text.
+     * @param  string   $url            The URL.
+     * @param  ?string  $header         The header.
+     * @param  ?string  $body           The body.
+     * @param  ?string  $footer         The footer.
+     *
+     * @return Response
+     *
+     * @throws Response\ResponseException
+     */
+    public function sendCtaUrl(string $to, string $displayText, string $url, ?string $header, ?string $body, ?string $footer): Response
+    {
+        $message = new Message\CtaUrlMessage($to, $displayText, $url, $header, $body, $footer, $this->reply_to);
+        $request = new Request\MessageRequest\RequestCtaUrlMessage(
+            $message,
+            $this->app->accessToken(),
+            $this->app->fromPhoneNumberId(),
+            $this->timeout
+        );
+
+        return $this->client->sendMessage($request);
+    }
+
     public function sendButton(string $to, string $body, ButtonAction $action, ?string $header = null, ?string $footer = null): Response
     {
         $message = new Message\ButtonReplyMessage(

--- a/tests/Integration/WhatsAppCloudApiTest.php
+++ b/tests/Integration/WhatsAppCloudApiTest.php
@@ -260,6 +260,21 @@ final class WhatsAppCloudApiTest extends TestCase
         $this->assertEquals(false, $response->isError());
     }
 
+    public function test_send_cta_url()
+    {
+        $response = $this->whatsapp_app_cloud_api->sendCtaUrl(
+            '<destination-phone-number>',
+            'Button text',
+            'https://www.example.com',
+            'The header',
+            'The body',
+            'The footer',
+        );
+
+        $this->assertEquals(200, $response->httpStatusCode());
+        $this->assertEquals(false, $response->isError());
+    }
+
     public function test_send_reply_buttons()
     {
         $buttonRows = [

--- a/tests/Unit/WhatsAppCloudApiTest.php
+++ b/tests/Unit/WhatsAppCloudApiTest.php
@@ -899,6 +899,65 @@ final class WhatsAppCloudApiTest extends TestCase
         $this->assertEquals(false, $response->isError());
     }
 
+    public function test_send_cta_url()
+    {
+        $to = $this->faker->phoneNumber;
+        $url = $this->buildMessageRequestUri();
+        $reply_to = $this->faker->uuid;
+
+        $ctaHeader = ['type' => 'text', 'text' => $this->faker->text(60)];
+        $ctaBody = ['text' => $this->faker->text(1024)];
+        $ctaFooter = ['text' => $this->faker->text(60)];
+        $ctaAction = [
+            'name' => 'cta_url',
+            'parameters' => [
+                'display_text' => $this->faker->text(24),
+                'url' => $this->faker->url,
+            ]
+        ];
+
+        $body = [
+            'messaging_product' => 'whatsapp',
+            'recipient_type' => 'individual',
+            'to' => $to,
+            'type' => 'interactive',
+            'interactive' => [
+                'type' => 'cta_url',
+                'header' => $ctaHeader,
+                'body' => $ctaBody,
+                'footer' => $ctaFooter,
+                'action' => $ctaAction,
+            ],
+            'context' => [
+                'message_id' => $reply_to,
+            ],
+        ];
+        $headers = [
+            'Authorization' => 'Bearer ' . $this->access_token,
+        ];
+
+        $this->client_handler
+            ->postJsonData($url, $body, $headers, Argument::type('int'))
+            ->shouldBeCalled()
+            ->willReturn(new RawResponse($headers, $this->successfulMessageNodeResponse(), 200));
+
+        $response = $this->whatsapp_app_cloud_api
+            ->replyTo($reply_to)
+            ->sendCtaUrl(
+                $to,
+                $ctaAction['parameters']['display_text'],
+                $ctaAction['parameters']['url'],
+                $ctaHeader['text'],
+                $ctaBody['text'],
+                $ctaFooter['text'],
+            );
+
+        $this->assertEquals(200, $response->httpStatusCode());
+        $this->assertEquals(json_decode($this->successfulMessageNodeResponse(), true), $response->decodedBody());
+        $this->assertEquals($this->successfulMessageNodeResponse(), $response->body());
+        $this->assertEquals(false, $response->isError());
+    }
+
     public function test_send_reply_buttons()
     {
         $to = $this->faker->phoneNumber;


### PR DESCRIPTION
This PR adds support of the [CTA URL](https://developers.facebook.com/docs/whatsapp/cloud-api/guides/send-messages/#cta-url-buttons) message.
Should respect OP guidelines
README updated
Tests implemented

Successfully tested on my own project.