### PR TITLE
Add react to message

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,27 @@ $whatsapp_cloud_api
     );
 ```
 
+### React to a Message
+
+You can react to a message from your conversations if you know the messageid
+
+```php
+<?php
+
+$whatsapp_cloud_api->sendReaction(
+        '<destination-phone-number>',
+        '<message-id-to-react-to>',
+        '👍', // the emoji
+    );
+
+// Unreact to a message
+$whatsapp_cloud_api->sendReaction(
+        '<destination-phone-number>',
+        '<message-id-to-unreact-to>'
+    );
+
+```
+
 ## Media messages
 ### Upload media resources
 Media messages accept as identifiers an Internet URL pointing to a public resource (image, video, audio, etc.). When you try to send a media message from a URL you must instantiate the `LinkID` object.
@@ -413,6 +434,7 @@ Fields list: https://developers.facebook.com/docs/whatsapp/cloud-api/reference/b
 - Upload media resources to WhatsApp servers
 - Download media resources from WhatsApp servers
 - Mark messages as read
+- React to a Message
 - Get/Update Business Profile
 - Webhook verification
 - Webhook notifications

--- a/src/Message/ReactionMessage.php
+++ b/src/Message/ReactionMessage.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Netflie\WhatsAppCloudApi\Message;
+
+final class ReactionMessage extends Message
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected string $type = 'reaction';
+
+    private $emoji;
+
+    private $message_id;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(string $to, string $message_id, string $emoji)
+    {
+        $this->emoji = $emoji;
+        $this->message_id = $message_id;
+
+        parent::__construct($to, null);
+    }
+
+    public function emoji(): string
+    {
+        return $this->emoji;
+    }
+
+    public function message_id(): string
+    {
+        return $this->message_id;
+    }
+}

--- a/src/Request/MessageRequest/RequestReactionMessage.php
+++ b/src/Request/MessageRequest/RequestReactionMessage.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Netflie\WhatsAppCloudApi\Request\MessageRequest;
+
+use Netflie\WhatsAppCloudApi\Request\MessageRequest;
+
+final class RequestReactionMessage extends MessageRequest
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function body(): array
+    {
+        $body = [
+            'messaging_product' => $this->message->messagingProduct(),
+            'recipient_type' => $this->message->recipientType(),
+            'to' => $this->message->to(),
+            'type' => $this->message->type(),
+            $this->message->type() => [
+                'message_id' => $this->message->message_id(),
+                'emoji' => $this->message->emoji(),
+            ],
+        ];
+
+        return $body;
+    }
+}

--- a/src/WhatsAppCloudApi.php
+++ b/src/WhatsAppCloudApi.php
@@ -414,6 +414,30 @@ class WhatsAppCloudApi
     }
 
     /**
+     * Sends a reaction to a provided message id.
+     *
+     * @param  string   $to             WhatsApp ID or phone number for the person you want to send a message to.
+     * @param  string   $message_id     The ID of the message to react to.
+     * @param  string   $emoji          The emoji to use as a reaction.
+     * @return Response
+     *
+     * @throws Response\ResponseException
+     */
+    public function sendReaction(string $to, string $message_id, string $emoji = ''): Response
+    {
+        $message = new Message\ReactionMessage($to, $message_id, $emoji);
+
+        $request = new Request\MessageRequest\RequestReactionMessage(
+            $message,
+            $this->app->accessToken(),
+            $this->app->fromPhoneNumberId(),
+            $this->timeout
+        );
+
+        return $this->client->sendMessage($request);
+    }
+
+    /**
      * Get Business Profile
      *
      * @param  string    $fields WhatsApp profile fields.

--- a/tests/Integration/WhatsAppCloudApiTest.php
+++ b/tests/Integration/WhatsAppCloudApiTest.php
@@ -301,6 +301,37 @@ final class WhatsAppCloudApiTest extends TestCase
         $this->assertEquals(false, $response->isError());
     }
 
+    public function test_send_reaction_message()
+    {
+        $this->markTestIncomplete(
+            'This test should use a real message ID.'
+        );
+
+        $response = $this->whatsapp_app_cloud_api->sendReaction(
+            WhatsAppCloudApiTestConfiguration::$to_phone_number_id,
+            'wamid.HBgMMjU2NzQyMDMwNDAzFQIAERgSMEU2MkE3Q0I3RTEyRDU5NzIwAA==',
+            '👍'
+        );
+
+        $this->assertEquals(200, $response->httpStatusCode());
+        $this->assertEquals(false, $response->isError());
+    }
+
+    public function test_send_remove_reaction_message()
+    {
+        $this->markTestIncomplete(
+            'This test should use a real message ID.'
+        );
+
+        $response = $this->whatsapp_app_cloud_api->sendReaction(
+            WhatsAppCloudApiTestConfiguration::$to_phone_number_id,
+            'wamid.HBgMMjU2NzQyMDMwNDAzFQIAERgSMEU2MkE3Q0I3RTEyRDU5NzIwAA=='
+        );
+
+        $this->assertEquals(200, $response->httpStatusCode());
+        $this->assertEquals(false, $response->isError());
+    }
+
     public function test_upload_media()
     {
         $response = $this->whatsapp_app_cloud_api->uploadMedia('tests/Support/netflie.png');

--- a/tests/Integration/WhatsAppCloudApiTest.php
+++ b/tests/Integration/WhatsAppCloudApiTest.php
@@ -303,13 +303,17 @@ final class WhatsAppCloudApiTest extends TestCase
 
     public function test_send_reaction_message()
     {
-        $this->markTestIncomplete(
-            'This test should use a real message ID.'
+        $textMessage = $this->whatsapp_app_cloud_api->sendTextMessage(
+            WhatsAppCloudApiTestConfiguration::$to_phone_number_id,
+            'This text will receive a reaction',
+            true
         );
+
+        $messageId = $textMessage->decodedBody()['messages'][0]['id'];
 
         $response = $this->whatsapp_app_cloud_api->sendReaction(
             WhatsAppCloudApiTestConfiguration::$to_phone_number_id,
-            'wamid.HBgMMjU2NzQyMDMwNDAzFQIAERgSMEU2MkE3Q0I3RTEyRDU5NzIwAA==',
+            $messageId,
             '👍'
         );
 
@@ -319,13 +323,25 @@ final class WhatsAppCloudApiTest extends TestCase
 
     public function test_send_remove_reaction_message()
     {
-        $this->markTestIncomplete(
-            'This test should use a real message ID.'
+        $textMessage = $this->whatsapp_app_cloud_api->sendTextMessage(
+            WhatsAppCloudApiTestConfiguration::$to_phone_number_id,
+            'This text will receive a reaction and then the reaction will be removed',
+            true
         );
+
+        $messageId = $textMessage->decodedBody()['messages'][0]['id'];
+
+        $reactToMessage = $this->whatsapp_app_cloud_api->sendReaction(
+            WhatsAppCloudApiTestConfiguration::$to_phone_number_id,
+            $messageId,
+            '👍'
+        );
+
+        // sleep(3); // can delay next request to see reaction
 
         $response = $this->whatsapp_app_cloud_api->sendReaction(
             WhatsAppCloudApiTestConfiguration::$to_phone_number_id,
-            'wamid.HBgMMjU2NzQyMDMwNDAzFQIAERgSMEU2MkE3Q0I3RTEyRDU5NzIwAA=='
+            $messageId
         );
 
         $this->assertEquals(200, $response->httpStatusCode());

--- a/tests/Unit/WhatsAppCloudApiTest.php
+++ b/tests/Unit/WhatsAppCloudApiTest.php
@@ -1170,6 +1170,81 @@ final class WhatsAppCloudApiTest extends TestCase
         $this->assertEquals(false, $response->isError());
     }
 
+    public function test_send_reaction_message()
+    {
+        $to = $this->faker->phoneNumber;
+        $url = $this->buildMessageRequestUri();
+        $emoji = $this->faker->emoji;
+        $message_id = $this->faker->uuid;
+
+        $body = [
+            'messaging_product' => 'whatsapp',
+            'recipient_type' => 'individual',
+            'to' => $to,
+            'type' => 'reaction',
+            'reaction' => [
+                'message_id' => $message_id,
+                'emoji' => $emoji,
+            ],
+        ];
+        $headers = [
+            'Authorization' => 'Bearer ' . $this->access_token,
+        ];
+
+        $this->client_handler
+            ->postJsonData($url, $body, $headers, Argument::type('int'))
+            ->shouldBeCalled()
+            ->willReturn(new RawResponse($headers, $this->successfulMessageNodeResponse(), 200));
+
+        $response = $this->whatsapp_app_cloud_api->sendReaction(
+            $to,
+            $message_id,
+            $emoji
+        );
+
+        $this->assertEquals(200, $response->httpStatusCode());
+        $this->assertEquals(json_decode($this->successfulMessageNodeResponse(), true), $response->decodedBody());
+        $this->assertEquals($this->successfulMessageNodeResponse(), $response->body());
+        $this->assertEquals(false, $response->isError());
+    }
+
+    public function test_send_remove_reaction_message()
+    {
+        $to = $this->faker->phoneNumber;
+        $url = $this->buildMessageRequestUri();
+        $emoji = '';
+        $message_id = $this->faker->uuid;
+
+        $body = [
+            'messaging_product' => 'whatsapp',
+            'recipient_type' => 'individual',
+            'to' => $to,
+            'type' => 'reaction',
+            'reaction' => [
+                'message_id' => $message_id,
+                'emoji' => $emoji,
+            ],
+        ];
+        $headers = [
+            'Authorization' => 'Bearer ' . $this->access_token,
+        ];
+
+        $this->client_handler
+            ->postJsonData($url, $body, $headers, Argument::type('int'))
+            ->shouldBeCalled()
+            ->willReturn(new RawResponse($headers, $this->successfulMessageNodeResponse(), 200));
+
+        $response = $this->whatsapp_app_cloud_api->sendReaction(
+            $to,
+            $message_id
+        );
+
+        $this->assertEquals(200, $response->httpStatusCode());
+        $this->assertEquals(json_decode($this->successfulMessageNodeResponse(), true), $response->decodedBody());
+        $this->assertEquals($this->successfulMessageNodeResponse(), $response->body());
+        $this->assertEquals(false, $response->isError());
+    }
+
     private function buildBaseUri(): string
     {
         return Client::BASE_GRAPH_URL . '/' . static::TEST_GRAPH_VERSION . '/';


### PR DESCRIPTION
@aalbarca 

This is an extract from the previously bundled PR.

About the empty string for the emoji, it's stated here: https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages under the **Reaction Object** table. It states that one can pass empty string to remove a previously sent emoji. I've also tested these and they're working