### PR TITLE
adding flow message support

### DIFF
--- a/src/Message/CtaUrl/TitleHeader.php
+++ b/src/Message/CtaUrl/TitleHeader.php
@@ -2,8 +2,6 @@
 
 namespace Netflie\WhatsAppCloudApi\Message\CtaUrl;
 
-use Netflie\WhatsAppCloudApi\Message\CtaUrl\Header;
-
 final class TitleHeader extends Header
 {
     protected string $title;

--- a/src/Request/BusinessProfileRequest/UpdateBusinessProfileRequest.php
+++ b/src/Request/BusinessProfileRequest/UpdateBusinessProfileRequest.php
@@ -33,7 +33,7 @@ final class UpdateBusinessProfileRequest extends Request
     {
         return array_merge(
             [
-                'messaging_product' => 'whatsapp'
+                'messaging_product' => 'whatsapp',
             ],
             $this->information
         );

--- a/src/WebHook/Notification/Flow.php
+++ b/src/WebHook/Notification/Flow.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Netflie\WhatsAppCloudApi\WebHook\Notification;
+
+final class Flow extends MessageNotification
+{
+    private string $name;
+
+    private string $body;
+
+    private string $response;
+
+    public function __construct(
+        string $id,
+        Support\Business $business,
+        string $name,
+        string $body,
+        string $response,
+        string $received_at_timestamp
+    ) {
+        parent::__construct($id, $business, $received_at_timestamp);
+
+        $this->name = $name;
+        $this->body = $body;
+        $this->response = $response;
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function response(): string
+    {
+        return $this->response;
+    }
+}

--- a/src/WebHook/Notification/MessageNotificationFactory.php
+++ b/src/WebHook/Notification/MessageNotificationFactory.php
@@ -77,6 +77,19 @@ class MessageNotificationFactory
                     $message['timestamp']
                 );
             case 'interactive':
+                if(isset($message['interactive']['nfm_reply'])) {
+                    $nfmReply = $message['interactive']['nfm_reply'];
+
+                    return new Flow(
+                        $message['id'],
+                        new Support\Business($metadata['phone_number_id'], $metadata['display_phone_number']),
+                        $nfmReply['name'],
+                        $nfmReply['body'],
+                        $nfmReply['response_json'] ?? '',
+                        $message['timestamp'],
+                    );
+                }
+
                 return new Interactive(
                     $message['id'],
                     new Support\Business($metadata['phone_number_id'], $metadata['display_phone_number']),

--- a/src/WebHook/Notification/MessageNotificationFactory.php
+++ b/src/WebHook/Notification/MessageNotificationFactory.php
@@ -77,7 +77,7 @@ class MessageNotificationFactory
                     $message['timestamp']
                 );
             case 'interactive':
-                if(isset($message['interactive']['nfm_reply'])) {
+                if (isset($message['interactive']['nfm_reply'])) {
                     $nfmReply = $message['interactive']['nfm_reply'];
 
                     return new Flow(

--- a/tests/Integration/ClientTest.php
+++ b/tests/Integration/ClientTest.php
@@ -96,7 +96,7 @@ final class ClientTest extends TestCase
         $request = new Request\BusinessProfileRequest\UpdateBusinessProfileRequest(
             [
                 'about' => 'About text',
-                'email' => 'my-email@email.com'
+                'email' => 'my-email@email.com',
             ],
             WhatsAppCloudApiTestConfiguration::$access_token,
             WhatsAppCloudApiTestConfiguration::$from_phone_number_id

--- a/tests/Integration/WhatsAppCloudApiTest.php
+++ b/tests/Integration/WhatsAppCloudApiTest.php
@@ -334,7 +334,7 @@ final class WhatsAppCloudApiTest extends TestCase
     {
         $response = $this->whatsapp_app_cloud_api->updateBusinessProfile([
             'about' => 'About text',
-            'email' => 'my-email@email.com'
+            'email' => 'my-email@email.com',
         ]);
 
         $this->assertEquals(200, $response->httpStatusCode());

--- a/tests/Unit/WebHook/NotificationFactoryTest.php
+++ b/tests/Unit/WebHook/NotificationFactoryTest.php
@@ -768,6 +768,61 @@ final class NotificationFactoryTest extends TestCase
         $this->assertEquals('', $notification->description());
     }
 
+    public function test_build_from_payload_can_build_a_flow_notification()
+    {
+        $payload = json_decode('{
+          "object": "whatsapp_business_account",
+          "entry": [
+            {
+              "id": "WHATSAPP_BUSINESS_ACCOUNT_ID",
+              "changes": [
+                {
+                  "value": {
+                      "messaging_product": "whatsapp",
+                      "metadata": {
+                           "display_phone_number": "PHONE_NUMBER",
+                           "phone_number_id": "PHONE_NUMBER_ID"
+                      },
+                      "contacts": [
+                        {
+                          "profile": {
+                            "name": "NAME"
+                          },
+                          "wa_id": "PHONE_NUMBER_ID"
+                        }
+                      ],
+                      "messages": [
+                        {
+                          "from": "PHONE_NUMBER_ID",
+                          "id": "wamid.ID",
+                          "timestamp": 1669233778,
+                          "interactive": {
+                            "type": "nfm_reply",
+                            "nfm_reply": {
+                              "response_json": "{\"screen_0_name_0\":\"Email\",\"screen_0_orderNumber_1\":\"ID\",\"flow_token\":\"unused\"}",
+                              "body": "Sent",
+                              "name": "flow"
+                            }
+                          },
+                          "type": "interactive"
+                        }
+                      ]
+                  },
+                  "field": "messages"
+                }
+              ]
+            }
+          ]
+        }', true);
+
+        $notification = $this->notification_factory->buildFromPayload($payload);
+
+        $this->assertInstanceOf(Notification\Flow::class, $notification);
+        $this->assertEquals('flow', $notification->name());
+        $this->assertEquals('Sent', $notification->body());
+        $this->assertEquals('{"screen_0_name_0":"Email","screen_0_orderNumber_1":"ID","flow_token":"unused"}', $notification->response());
+    }
+
     public function test_build_from_payload_can_build_an_order_notification()
     {
         $payload = json_decode('{

--- a/tests/Unit/WhatsAppCloudApiTest.php
+++ b/tests/Unit/WhatsAppCloudApiTest.php
@@ -914,7 +914,7 @@ final class WhatsAppCloudApiTest extends TestCase
             'parameters' => [
                 'display_text' => $this->faker->text(24),
                 'url' => $this->faker->url,
-            ]
+            ],
         ];
 
         $body = [


### PR DESCRIPTION
Added support for flow message

<img width="719" alt="image" src="https://github.com/netflie/whatsapp-cloud-api/assets/13960560/f7ddefc0-dd33-44b4-bd88-4a2ba89db17c">

tested on payload below
```
{
    "object": "whatsapp_business_account",
    "entry": [{
        "id": "WHATSAPP_BUSINESS_ACCOUNT_ID",
        "changes": [{
            "value": {
                "messaging_product": "whatsapp",
                "metadata": {
                    "display_phone_number": "PHONE_NUMBER",
                    "phone_number_id": "PHONE_NUMBER_ID"
                },
                "contacts": [{
                    "profile": {
                        "name": "NAME"
                    },
                    "wa_id": "WHATSAPP_ID"
                }],
                "messages": [{
                    "context": {
                        "from": "PHONE_NUMBER",
                        "id": "wamid.ID"
                    },
                    "from": "16315551234",
                    "id": "wamid.ID",
                    "timestamp": 1669233778,
                    "type": "interactive",
                    "interactive": {
                        "type": "nfm_reply",
                        "nfm_reply": {
                            "response_json": "{\"screen_0_name_0\":\"EMAIL\",\"screen_0_orderNumber_1\":\"ORDER_NUMBER\",\"screen_0_topicRadio_2\":\"TOPIC\",\"screen_0_DatePicker_3\":\"DATE_PICKER_TIMESTAMP\",\"flow_token\":\"unused\"}",
                            "body": "BODY",
                            "name": "flow"
                        }
                    }
                }]
            },
            "field": "messages"
        }]
    }]
}
```

