### PR TITLE
Support for ctwa_clid

### DIFF
--- a/src/WebHook/Notification/MessageNotificationFactory.php
+++ b/src/WebHook/Notification/MessageNotificationFactory.php
@@ -146,7 +146,8 @@ class MessageNotificationFactory
                 $message['referral']['body'] ?? '',
                 $message['referral']['media_type'] ?? '',
                 $message['referral']['image_url'] ?? $message['referral']['video_url'] ?? '',
-                $message['referral']['thumbnail_url'] ?? ''
+                $message['referral']['thumbnail_url'] ?? '',
+                $message['referral']['ctwa_clid'] ?? ''
             ));
         }
 

--- a/src/WebHook/Notification/Support/Referral.php
+++ b/src/WebHook/Notification/Support/Referral.php
@@ -20,6 +20,8 @@ final class Referral
 
     private string $thumbnail_url;
 
+    private string $ctwa_clid;
+
     public function __construct(
         string $source_id,
         string $source_url,
@@ -28,7 +30,8 @@ final class Referral
         string $body,
         string $media_type,
         string $media_url,
-        string $thumbnail_url
+        string $thumbnail_url,
+        string $ctwa_clid
     ) {
         $this->source_id = $source_id;
         $this->source_url = $source_url;
@@ -38,6 +41,7 @@ final class Referral
         $this->media_type = $media_type;
         $this->media_url = $media_url;
         $this->thumbnail_url = $thumbnail_url;
+        $this->ctwa_clid = $ctwa_clid;
     }
 
     public function sourceId(): string
@@ -78,5 +82,10 @@ final class Referral
     public function thumbnailUrl(): string
     {
         return $this->thumbnail_url;
+    }
+
+    public function ctwaClid(): string
+    {
+        return $this->ctwa_clid;
     }
 }


### PR DESCRIPTION
Support for ctwa_clid, a referral property sent at the message object: https://developers.facebook.com/docs/whatsapp/cloud-api/webhooks/components

It is useful for sending notifications to the Meta Conversion API: https://developers.facebook.com/docs/marketing-api/conversions-api/business-messaging/?locale=en_US