### PR TITLE
Add support for frequently forwarded messages in context

### DIFF
--- a/src/WebHook/Notification/MessageNotification.php
+++ b/src/WebHook/Notification/MessageNotification.php
@@ -35,6 +35,15 @@ abstract class MessageNotification extends Notification
         return $this->context->isForwarded();
     }
 
+    public function isFrequentlyForwarded(): bool
+    {
+        if (!$this->context) {
+            return false;
+        }
+
+        return $this->context->isFrequentlyForwarded();
+    }
+
     public function context(): ?Support\Context
     {
         return $this->context;

--- a/src/WebHook/Notification/MessageNotificationFactory.php
+++ b/src/WebHook/Notification/MessageNotificationFactory.php
@@ -146,6 +146,7 @@ class MessageNotificationFactory
             $notification->withContext(new Support\Context(
                 $message['context']['id'] ?? null,
                 $message['context']['forwarded'] ?? false,
+                $message['context']['frequently_forwarded'] ?? false,
                 $referred_product ?? null
             ));
         }

--- a/src/WebHook/Notification/Support/Context.php
+++ b/src/WebHook/Notification/Support/Context.php
@@ -8,15 +8,19 @@ final class Context
 
     private bool $forwarded;
 
+    private bool $frequently_forwarded;
+
     private ?ReferredProduct $referred_product;
 
     public function __construct(
         string $replying_to_message_id = null,
         bool $forwarded = false,
+        bool $frequently_forwarded = false,
         ReferredProduct $referred_product = null
     ) {
         $this->replying_to_message_id = $replying_to_message_id;
         $this->forwarded = $forwarded;
+        $this->frequently_forwarded = $frequently_forwarded;
         $this->referred_product = $referred_product;
     }
 
@@ -28,6 +32,11 @@ final class Context
     public function isForwarded(): bool
     {
         return $this->forwarded;
+    }
+
+    public function isFrequentlyForwarded(): bool
+    {
+        return $this->frequently_forwarded;
     }
 
     public function hasReferredProduct(): bool


### PR DESCRIPTION
We have this field in the context object

frequently_forwarded — Boolean. Set to true if the message received by the business has been forwarded more than 5 times.